### PR TITLE
honor defaults from mongoose models

### DIFF
--- a/lib/display-model.js
+++ b/lib/display-model.js
@@ -171,6 +171,9 @@ function Model(modelName, args) {
             {legend:this.title, fields:this.edit_fields}
         ]
     });
+    this.__defineGetter__('defaults', function onDefaultsGet() {
+        return find('defaults', args);
+    });
 }
 Model.prototype.pathFor = function (path) {
     var ret = util.depth(this.paths, toSubSchema(path));

--- a/plugins/generator/views/modelcollections.js
+++ b/plugins/generator/views/modelcollections.js
@@ -3,13 +3,16 @@ define([
     'Backbone'
 ], function(_, Backbone) {
     "use strict";
+
     //we define these together because they often link together and if they are in seperate callbacks bad things happen.
-  //  var defaults = {{html _defaults()}};
+
     var schema = {{html JSON.stringify(model.schemaFor(model.fieldsets || model.edit_fields))}};
+    var defaults = {{html JSON.stringify(model.defaults)}};
+
     var Model = Backbone.Model.extend({
         urlRoot:'${api}/${model.modelName}',
         schema:schema,
-       // defaults:defaults,
+        defaults:defaults,
         initialize: function() {
         }
         ,parse:function(resp) {

--- a/plugins/mongoose/mmodel.js
+++ b/plugins/mongoose/mmodel.js
@@ -27,6 +27,15 @@ module.exports = function MModel(m, manager) {
             return display.list_fields;
 
     });
+
+    var defaults = {};
+    Object.keys(m.schema.tree).forEach(function(k) {
+        var d = m.schema.tree[k].default;
+        if (typeof d === 'undefined') return;
+	defaults[k] = d;
+    });
+    this.defaults = defaults;
+
     this.__defineGetter__('paths', function () {
         var ret = {};
         _u.each(m.schema.tree, function (v,k) {


### PR DESCRIPTION
With these changes, defaults in mongoose models show up as default values in form elements when creating new items.
