### PR TITLE
Passport plugin fix

### DIFF
--- a/plugins/passport/passport.js
+++ b/plugins/passport/passport.js
@@ -68,7 +68,7 @@ PassportPlugin.prototype.logOut = function(req,res,next){
 
 PassportPlugin.prototype.filters = function () {
     var app = this.app;
-    app.post(this.pluginUrl, this.authenticate.bind(this),   this.onAuth.bind(this));
+    app.post(this.pluginUrl, this.authenticate.bind(this), this.ensureAuthenticated.bind(this), this.onAuth.bind(this));
 
     app.get(this.pluginUrl + '/check', this.ensureAuthenticated.bind(this), this.onAuth.bind(this));
 


### PR DESCRIPTION
You were able to authenticate by having the form empty and simply click "login" on the form :-)    
